### PR TITLE
fix(phpcs): add exclusions for default files

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,6 +17,8 @@
     <file>config/</file>
     <exclude-pattern>config/bootstrap.php</exclude-pattern>
     <file>src/</file>
+    <exclude-pattern>src/Kernel.php</exclude-pattern>
     <file>tests/</file>
+    <exclude-pattern>tests/bootstrap.php</exclude-pattern>
 
 </ruleset>

--- a/symfony.lock
+++ b/symfony.lock
@@ -112,12 +112,6 @@
     "laminas/laminas-code": {
         "version": "4.2.0"
     },
-    "laminas/laminas-eventmanager": {
-        "version": "3.3.1"
-    },
-    "laminas/laminas-zendframework-bridge": {
-        "version": "1.2.0"
-    },
     "monolog/monolog": {
         "version": "1.26.0"
     },
@@ -439,6 +433,9 @@
     },
     "symfony/polyfill-php80": {
         "version": "v1.22.1"
+    },
+    "symfony/polyfill-php81": {
+        "version": "v1.23.0"
     },
     "symfony/process": {
         "version": "v4.4.20"


### PR DESCRIPTION
Add exclusions for PHP files that are generated by Symfony/Libraries.